### PR TITLE
Strengthen the password validator by using it in the APIView

### DIFF
--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -1,5 +1,3 @@
-from django.contrib.auth.password_validation import validate_password
-from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
@@ -12,11 +10,3 @@ class EmailSerializer(serializers.Serializer):
 class PasswordTokenSerializer(serializers.Serializer):
     password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
     token = serializers.CharField()
-
-    def validate_password(self, password):
-        try:
-            validate_password(password)
-        except ValidationError as e:
-            raise serializers.ValidationError(e.messages)
-
-        return password


### PR DESCRIPTION
As per the the name of pull request, validating password in the APIView makes more sense as we are able to access the user. This allows us to validate password against UserAttributeSimilarityVlidator, MinimumLengthValidator, CommonPasswordValidator, NumericPasswordValidator or any other custom validators that have been defined in the project config under ```AUTH_PASSWORD_VALIDATORS```.

For ex:
```
    AUTH_PASSWORD_VALIDATORS = [
        {
            'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
        },
        {
            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
            'OPTIONS': {
                'min_length': 12,
            }
        },
        {
            'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
        },
        {
            'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
        },
    ]
```
