### PR TITLE
fixed issues with configurable lookup

### DIFF
--- a/django_rest_passwordreset/models.py
+++ b/django_rest_passwordreset/models.py
@@ -1,4 +1,7 @@
+import importlib
+
 from django.conf import settings
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
@@ -94,6 +97,23 @@ def get_password_reset_lookup_field():
     :return: lookup field
     """
     return getattr(settings, 'DJANGO_REST_LOOKUP_FIELD', 'email')
+
+
+def get_password_reset_lookup_serializer():
+    """
+    Returns the serializer to user on the password reset lookup field
+    Set Django SETTINGS.DJANGO_REST_LOOKUP_SERIALIZER to overwrite this time
+    :return: serializer class
+    """
+
+    serializer_classname = getattr(settings, 'DJANGO_REST_LOOKUP_SERIALIZER', 'django_rest_passwordreset.serializers.EmailSerializer')
+
+    components = serializer_classname.rsplit('.', 1)
+
+    module = importlib.import_module(components[0])
+    serializer_class = getattr(module, components[1])
+
+    return serializer_class
 
 
 def clear_expired(expiry_time):

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -4,12 +4,17 @@ from rest_framework import serializers
 
 __all__ = [
     'EmailSerializer',
+    'UsernameSerializer',
     'PasswordTokenSerializer',
 ]
 
 
 class EmailSerializer(serializers.Serializer):
     email = serializers.EmailField()
+
+
+class UsernameSerializer(serializers.Serializer):
+    username = serializers.CharField()
 
 
 class PasswordTokenSerializer(serializers.Serializer):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -123,3 +123,5 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+# DJANGO_REST_LOOKUP_FIELD = 'email'
+# DJANGO_REST_LOOKUP_SERIALIZER = 'django_rest_passwordreset.serializers.EmailSerializer'

--- a/tests/test/helpers.py
+++ b/tests/test/helpers.py
@@ -41,10 +41,10 @@ class HelperMixin:
 
         return user.check_password(password)
 
-    def rest_do_request_reset_token(self, email, HTTP_USER_AGENT='', REMOTE_ADDR='127.0.0.1'):
+    def rest_do_request_reset_token(self, lookup, value, HTTP_USER_AGENT='', REMOTE_ADDR='127.0.0.1'):
         """ REST API wrapper for requesting a password reset token """
         data = {
-            'email': email
+            lookup: value
         }
 
         return self.client.post(

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -1,10 +1,14 @@
 import json
+
+from django.conf import settings
+
 from django.test import override_settings
 from django.contrib.auth.models import User
 from django.db.models import Q
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django_rest_passwordreset.models import ResetPasswordToken
+from django_rest_passwordreset.serializers import UsernameSerializer
 from tests.test.helpers import HelperMixin, patch
 
 
@@ -16,11 +20,12 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.setUpUrls()
         self.user1 = User.objects.create_user("user1", "user1@mail.com", "secret1")
         self.user2 = User.objects.create_user("user2", "user2@mail.com", "secret2")
-        self.user3 = User.objects.create_user("user3@mail.com", "not-that-mail@mail.com", "secret3")
+        self.user3 = User.objects.create_user("user3", "user3@mail.com", "secret3")
 
     def test_try_reset_password_email_does_not_exist(self):
         """ Tests requesting a token for an email that does not exist """
-        response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="foobar@doesnotexist.com")
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         decoded_response = json.loads(response.content.decode())
         # response should have "email" in it
@@ -33,7 +38,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         # there should be zero tokens
         self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
 
-        response = self.rest_do_request_reset_token(email="user1@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user1@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # check that the signal was sent once
         self.assertTrue(mock_reset_password_token_created.called)
@@ -45,7 +50,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
 
         # if the same user tries to reset again, the user will get the same token again
-        response = self.rest_do_request_reset_token(email="user1@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user1@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(mock_reset_password_token_created.call_count, 2)
         last_reset_password_token = mock_reset_password_token_created.call_args[1]['reset_password_token']
@@ -79,15 +84,16 @@ class AuthTestCase(APITestCase, HelperMixin):
         )
 
     @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
-    @override_settings(DJANGO_REST_LOOKUP_FIELD='username')
+    @override_settings(DJANGO_REST_LOOKUP_FIELD="username")
+    @override_settings(DJANGO_REST_LOOKUP_SERIALIZER="django_rest_passwordreset.serializers.UsernameSerializer")
     def test_reset_password_different_lookup(self, mock_reset_password_token_created):
-        """ Tests resetting a password """
-
+        """ Tests resetting a password with a non-email lookup """
+        
         # there should be zero tokens
         self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
-
-        response = self.rest_do_request_reset_token(email="user3@mail.com")
+        response = self.rest_do_request_reset_token(lookup='username', value='user3')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
         # check that the signal was sent once
         self.assertTrue(mock_reset_password_token_created.called)
         self.assertEqual(mock_reset_password_token_created.call_count, 1)
@@ -98,7 +104,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
 
         # if the same user tries to reset again, the user will get the same token again
-        response = self.rest_do_request_reset_token(email="user3@mail.com")
+        response = self.rest_do_request_reset_token(lookup='username', value='user3')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(mock_reset_password_token_created.call_count, 2)
         last_reset_password_token = mock_reset_password_token_created.call_args[1]['reset_password_token']
@@ -109,7 +115,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         # and it should be assigned to user1
         self.assertEqual(
             ResetPasswordToken.objects.filter(key=last_reset_password_token.key).first().user.username,
-            "user3@mail.com"
+            "user3"
         )
 
         # try to reset the password
@@ -121,13 +127,13 @@ class AuthTestCase(APITestCase, HelperMixin):
 
         # try to login with the old username/password (should fail)
         self.assertFalse(
-            self.django_check_login("user3@mail.com", "secret3"),
+            self.django_check_login("user3", "secret3"),
             msg="User 3 should not be able to login with the old credentials"
         )
 
         # try to login with the new username/Password (should work)
         self.assertTrue(
-            self.django_check_login("user3@mail.com", "new_secret"),
+            self.django_check_login("user3", "new_secret"),
             msg="User 3 should be able to login with the modified credentials"
         )
 
@@ -139,7 +145,7 @@ class AuthTestCase(APITestCase, HelperMixin):
 
 
         # create a token for user 1
-        response = self.rest_do_request_reset_token(email="user1@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user1@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
         self.assertTrue(mock_reset_password_token_created.called)
@@ -147,7 +153,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         token1 = mock_reset_password_token_created.call_args[1]['reset_password_token']
 
         # create another token for user 2
-        response = self.rest_do_request_reset_token(email="user2@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user2@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         tokens = ResetPasswordToken.objects.all()
         self.assertEqual(tokens.count(), 2)
@@ -158,12 +164,12 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.assertNotEqual(tokens[0].key, tokens[1].key)
 
         # try to request another token, there should still always be two keys
-        response = self.rest_do_request_reset_token(email="user1@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user2@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
 
         # create another token for user 2
-        response = self.rest_do_request_reset_token(email="user2@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user2@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
 
@@ -203,7 +209,7 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.assertFalse(mock_pre_password_reset.called)
 
         # request token for user1
-        response = self.rest_do_request_reset_token(email="user1@mail.com")
+        response = self.rest_do_request_reset_token(lookup='email', value="user1@mail.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
 


### PR DESCRIPTION
The work performed in #5 by another developer appeared to be incomplete. In order to allow for a configurable lookup field, we have to allow the user to choose the serializer that will process that field as well, or else it will try to use the EmailSerializer to validate their chosen field.

I've implemented an example of how this could work. The user will have to add two settings values, **DJANGO_REST_LOOKUP_FIELD** and **DJANGO_REST_LOOKUP_SERIALIZER**