### PR TITLE
Fixed *length* word typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ DJANGO_REST_PASSWORDRESET_TOKEN_CONFIG = {
     "CLASS": "django_rest_passwordreset.tokens.RandomStringTokenGenerator",
     "OPTIONS": {
         "min_length": 20,
-        "max_lenght": 30
+        "max_length": 30
     }
 }
 ```


### PR DESCRIPTION
Related to this issue: https://github.com/anx-ckreuzberger/django-rest-passwordreset/issues/50 :)