### PR TITLE
Implement DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ The following settings can be set in Djangos ``settings.py`` file:
 * `DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME` - time in hours about how long the token is active (Default: 24)
 
   **Please note**: expired tokens are automatically cleared based on this setting in every call of ``ResetPasswordRequestToken.post``.
- 
+
+* `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` - will cause a 200 to be returned on `POST ${API_URL}/reset_password/`
+  even if the user doesn't exist in the databse (Default: False) 
+
 ### Signals
 
 * ``reset_password_token_created(sender, instance, reset_password_token)`` Fired when a reset password token is generated

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -119,10 +119,15 @@ class ResetPasswordRequestToken(GenericAPIView):
 
         # No active user found, raise a validation error
         if not active_user_found:
-            raise exceptions.ValidationError({
-                'email': [_(
-                    "There is no active user associated with this e-mail address or the password can not be changed")],
-            })
+            # if we dont want it to be known whether or not the email account
+            # exists in the db then we just return 200
+            if getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
+                return Response({'status': 'OK'})
+            else: 
+                raise exceptions.ValidationError({
+                    'email': [_(
+                        "There is no active user associated with this e-mail address or the password can not be changed")],
+                })
 
         # last but not least: iterate over all users that are active and can change their password
         # and create a Reset Password Token and send a signal with the created token

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -118,16 +118,12 @@ class ResetPasswordRequestToken(GenericAPIView):
                 active_user_found = True
 
         # No active user found, raise a validation error
-        if not active_user_found:
-            # if we dont want it to be known whether or not the email account
-            # exists in the db then we just return 200
-            if getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
-                return Response({'status': 'OK'})
-            else: 
-                raise exceptions.ValidationError({
-                    'email': [_(
-                        "There is no active user associated with this e-mail address or the password can not be changed")],
-                })
+        # but not if DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
+        if not active_user_found and not getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
+            raise exceptions.ValidationError({
+                'email': [_(
+                    "There is no active user associated with this e-mail address or the password can not be changed")],
+            })
 
         # last but not least: iterate over all users that are active and can change their password
         # and create a Reset Password Token and send a signal with the created token

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -225,3 +225,12 @@ class AuthTestCase(APITestCase, HelperMixin):
         # now the other two signals should have been called
         self.assertTrue(mock_post_password_reset.called)
         self.assertTrue(mock_pre_password_reset.called)
+
+    @override_settings(DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE=True)
+    def test_try_reset_password_email_does_not_exist_no_leakage_enabled(self):
+        """ 
+        Tests requesting a token for an email that does not exist when
+        DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
+        """ 
+        response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Background
- If a user doesnt exist in the DB, `django-rest-passwordreset` will return a 400
- This is undesirable for some use cases

## Changes
- Add `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` setting to cause 200 to be returned, even if the user isn't found
- Document setting in the README
- https://github.com/anx-ckreuzberger/django-rest-passwordreset/issues/53

## Tests
- [x] Added test case