### PR TITLE
Add setting to not require users to have usable password

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The following settings can be set in Djangos ``settings.py`` file:
 * `DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME` - time in hours about how long the token is active (Default: 24)
 
   **Please note**: expired tokens are automatically cleared based on this setting in every call of ``ResetPasswordRequestToken.post``.
+
+* `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD` - allows password reset for a user that does not 
+  [have a usable password](https://docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.has_usable_password) (Default: True)
  
 ### Signals
 

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -55,8 +55,8 @@ class ResetPasswordConfirm(GenericAPIView):
             reset_password_token.delete()
             return Response({'status': 'expired'}, status=status.HTTP_404_NOT_FOUND)
 
-        # change users password
-        if reset_password_token.user.has_usable_password():
+        # change users password (if we got to this code it means that the user is_active)
+        if reset_password_token.user.eligible_for_reset():
             pre_password_reset.send(sender=self.__class__, user=reset_password_token.user)
             try:
                 # validate the password against existing validators
@@ -114,7 +114,7 @@ class ResetPasswordRequestToken(GenericAPIView):
         # also check whether the password can be changed (is useable), as there could be users that are not allowed
         # to change their password (e.g., LDAP user)
         for user in users:
-            if user.is_active and user.has_usable_password():
+            if user.eligible_for_reset():
                 active_user_found = True
 
         # No active user found, raise a validation error
@@ -127,7 +127,7 @@ class ResetPasswordRequestToken(GenericAPIView):
         # last but not least: iterate over all users that are active and can change their password
         # and create a Reset Password Token and send a signal with the created token
         for user in users:
-            if user.is_active and user.has_usable_password():
+            if user.eligible_for_reset():
                 # define the token as none for now
                 token = None
 


### PR DESCRIPTION
## Background
- Currently `django-rest-passwordreset` requires that a user has a usable password before they are able to reset their password because some users such as LDAP users shouldn't be able to change their password
- I have run into a use case where users who are signed in via social media (eg Facebook or Google), may try and reset their password. They have a valid email and should be able to reset their password even if they don't have one set yet.
- I am proposing to add a setting `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD` which when set to `False` would allow users without a reusable password to reset their password

## Changes
- Add `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD` setting
- Abstract reset eligibility into `User.eligible_for_reset()` rather than a long conditional
  - This method checks `has_usable_password()` when `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD == True` *(this is default behaviour)*

## Testing
- [x] Added test case for default behaviour (this ensures backwards compatibility)
- [x] Added test case for new behaviour
