### PR TITLE
Implement Variant of ResetPasswordConfirm that validates a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The following settings can be set in Djangos ``settings.py`` file:
 * `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD` - allows password reset for a user that does not 
   [have a usable password](https://docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.has_usable_password) (Default: True)
  
+ * `DJANGO_REST_PASSWORDRESET_ALLOW_TOKEN_VALIDATION` - will cause `POST ${API_URL}/reset_password/confirm/` to return a 200 if a valid token is provided without a new password (Default: False)
+
 ### Signals
 
 * ``reset_password_token_created(sender, instance, reset_password_token)`` Fired when a reset password token is generated

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -1,4 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from rest_framework import serializers
 
@@ -15,3 +16,11 @@ class EmailSerializer(serializers.Serializer):
 class PasswordTokenSerializer(serializers.Serializer):
     password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
     token = serializers.CharField()
+
+    def __init__(self, *args, **kwargs):
+        password_optional = kwargs.pop('password_optional', False)
+
+        super(PasswordTokenSerializer, self).__init__(*args, **kwargs)
+
+        if password_optional:
+            self.fields['password'].required = False

--- a/tests/test/helpers.py
+++ b/tests/test/helpers.py
@@ -69,3 +69,17 @@ class HelperMixin:
             HTTP_USER_AGENT=HTTP_USER_AGENT,
             REMOTE_ADDR=REMOTE_ADDR
         )
+
+    def rest_do_check_token_valid(self, token, HTTP_USER_AGENT='', REMOTE_ADDR='127.0.0.1'):
+        """ REST API wrapper for checking token validity """
+        data = {
+            'token': token
+        }
+
+        return self.client.post(
+            self.reset_password_confirm_url,
+            data,
+            format='json',
+            HTTP_USER_AGENT=HTTP_USER_AGENT,
+            REMOTE_ADDR=REMOTE_ADDR
+        )


### PR DESCRIPTION
This implements #45 

If the user sets `DJANGO_REST_PASSWORDRESET_ALLOW_TOKEN_VALIDATION = True` in settings, 
the password field becomes optional in `ResetPasswordConfirm`.  It will return a 200 if a valid token is provided without a password.

If `DJANGO_REST_PASSWORDRESET_ALLOW_TOKEN_VALIDATION` is not set, or is set to False, `ResetPasswordConfirm` behaves as it did before - returning a 400 if a password isn't given.

I also added a couple of tests for this and updated the README.