### PR TITLE
Created endpoint for validating a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following endpoints are provided:
 
  * `POST ${API_URL}/reset_password/` - request a reset password token by using the ``email`` parameter
  * `POST ${API_URL}/reset_password/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
+ * `POST ${API_URL}/reset_password/validate_token/` - will return a 200 if a given ``token`` is valid
  
 where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset/`)
  

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 __all__ = [
     'EmailSerializer',
     'PasswordTokenSerializer',
+    'TokenSerializer',
 ]
 
 
@@ -14,4 +15,8 @@ class EmailSerializer(serializers.Serializer):
 
 class PasswordTokenSerializer(serializers.Serializer):
     password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
+    token = serializers.CharField()
+
+
+class TokenSerializer(serializers.Serializer):
     token = serializers.CharField()

--- a/django_rest_passwordreset/urls.py
+++ b/django_rest_passwordreset/urls.py
@@ -1,11 +1,12 @@
 """ URL Configuration for core auth
 """
 from django.conf.urls import url, include
-from django_rest_passwordreset.views import reset_password_request_token, reset_password_confirm
+from django_rest_passwordreset.views import reset_password_request_token, reset_password_confirm, reset_password_validate_token
 
 app_name = 'password_reset'
 
 urlpatterns = [
+    url(r'^validate_token/', reset_password_validate_token, name="reset-password-validate"),
     url(r'^confirm/', reset_password_confirm, name="reset-password-confirm"),
     url(r'^', reset_password_request_token, name="reset-password-request"),
 ]

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -9,7 +9,7 @@ from rest_framework import status, serializers, exceptions
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
-from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer
+from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, TokenSerializer
 from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, get_password_reset_token_expiry_time, \
     get_password_reset_lookup_field
 from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
@@ -17,11 +17,46 @@ from django_rest_passwordreset.signals import reset_password_token_created, pre_
 User = get_user_model()
 
 __all__ = [
+    'ValidateToken',
     'ResetPasswordConfirm',
     'ResetPasswordRequestToken',
+    'reset_password_validate_token',
     'reset_password_confirm',
     'reset_password_request_token'
 ]
+
+
+class ResetPasswordValidateToken(GenericAPIView):
+    """
+    An Api View which provides a method to verify that a token is valid
+    """
+    throttle_classes = ()
+    permission_classes = ()
+    serializer_class = TokenSerializer
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        token = serializer.validated_data['token']
+
+        # get token validation time
+        password_reset_token_validation_time = get_password_reset_token_expiry_time()
+
+        # find token
+        reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
+
+        if reset_password_token is None:
+            return Response({'status': 'notfound'}, status=status.HTTP_404_NOT_FOUND)
+
+        # check expiry date
+        expiry_date = reset_password_token.created_at + timedelta(hours=password_reset_token_validation_time)
+
+        if timezone.now() > expiry_date:
+            # delete expired token
+            reset_password_token.delete()
+            return Response({'status': 'expired'}, status=status.HTTP_404_NOT_FOUND)
+        
+        return Response({'status': 'OK'})
 
 
 class ResetPasswordConfirm(GenericAPIView):
@@ -152,5 +187,6 @@ class ResetPasswordRequestToken(GenericAPIView):
         return Response({'status': 'OK'})
 
 
+reset_password_validate_token = ResetPasswordValidateToken.as_view()
 reset_password_confirm = ResetPasswordConfirm.as_view()
 reset_password_request_token = ResetPasswordRequestToken.as_view()

--- a/tests/test/helpers.py
+++ b/tests/test/helpers.py
@@ -29,6 +29,7 @@ class HelperMixin:
         """ set up urls by using djangos reverse function """
         self.reset_password_request_url = reverse('password_reset:reset-password-request')
         self.reset_password_confirm_url = reverse('password_reset:reset-password-confirm')
+        self.reset_password_validate_token_url = reverse('password_reset:reset-password-validate')
 
     def django_check_login(self, username, password):
         """
@@ -64,6 +65,20 @@ class HelperMixin:
 
         return self.client.post(
             self.reset_password_confirm_url,
+            data,
+            format='json',
+            HTTP_USER_AGENT=HTTP_USER_AGENT,
+            REMOTE_ADDR=REMOTE_ADDR
+        )
+
+    def rest_do_validate_token(self, token, HTTP_USER_AGENT='', REMOTE_ADDR='127.0.0.1'):
+        """ REST API wrapper for validating a token """
+        data = {
+            'token': token
+        }
+
+        return self.client.post(
+            self.reset_password_validate_token_url,
             data,
             format='json',
             HTTP_USER_AGENT=HTTP_USER_AGENT,


### PR DESCRIPTION
Implements #45, but unlike #59, this uses a separate endpoint `/validate_token/` for token validation.

includes tests and updated readme.